### PR TITLE
Organize drawing

### DIFF
--- a/Core/config.h
+++ b/Core/config.h
@@ -63,4 +63,4 @@
 // Set to true if you want to disable playing audio via SoundService
 #define DEBUG_AudioDisabled false
 // Automatically open X gates from the start of the game (for faster testing)
-#define DEBUG_SkipGates 2
+#define DEBUG_SkipGates 0

--- a/Core/enums.h
+++ b/Core/enums.h
@@ -77,3 +77,11 @@ enum EnvironmentID : char {
 
     ENV_None = '\0'
 };
+
+// Used for determining what animation frames to use when drawing Entities
+enum AnimationID {
+    ANIM_Idle = 0,
+    ANIM_Walk = 1,
+    ANIM_Attack = 2,
+    ANIM_Paused = 3
+};

--- a/Core/main.cpp
+++ b/Core/main.cpp
@@ -227,6 +227,8 @@ int main(int argc, char **argv) {
             continue;
         }
 
+        bool tickedThisFrame = false; // True if there was a computation tick this frame (for animations)
+
         // Game Logic
         #ifdef DEBUG_MODE
             if (controller->accelerate)
@@ -241,6 +243,7 @@ int main(int argc, char **argv) {
         else if (GameTick >= 1) {
             ticks++;
             window.LogTick();
+            tickedThisFrame = true;
 
             // Tally sheep
             int sheepLeft = 0;
@@ -508,7 +511,7 @@ int main(int argc, char **argv) {
         // Draw all entities aside from Shepherd
         for (Entity* obj : levelEntities) {
             if (obj && obj->GetID() != EntityID::EE_Shepherd)
-                window.DrawEntity(obj->x, obj->y, obj->lastX, obj->lastY, obj->GetID(), obj->Flipped, obj->animation, obj->animationMetadata);
+                window.DrawEntity(obj, tickedThisFrame, DeltaTime);
         }
 
 
@@ -523,7 +526,7 @@ int main(int argc, char **argv) {
         SDL_SetRenderDrawBlendMode(window.canvas, blend);
 
         // Draw shepherd last
-        window.DrawEntity(player->x, player->y, player->lastX, player->lastY, player->GetID(), player->Flipped, player->animation, player->animationMetadata);
+        window.DrawEntity(player, tickedThisFrame, DeltaTime);
 
         // Draw GUI
         window.DrawStatusBar(player->GetHealth(), currentLevel->PuzzleStatus);

--- a/Core/main.cpp
+++ b/Core/main.cpp
@@ -263,7 +263,7 @@ int main(int argc, char **argv) {
             }
 
             if (!player->Paused) {      //If they player is not paused, let them move if input is given
-                player->animation = 0;
+                player->animation = AnimationID::ANIM_Idle;
 
                 player->lastX = player->x;
                 player->lastY = player->y;

--- a/Core/renderwindow.h
+++ b/Core/renderwindow.h
@@ -11,6 +11,7 @@
 #include "mathutil.h"
 
 #include "Core/enums.h"
+#include "Entities/entity.h"
 
 // Render Window - An individual window that renders things.
 class RenderWindow {
@@ -120,7 +121,7 @@ class RenderWindow {
     public:
         void FillViewportBackground(EnvironmentID environment);
         void DrawTile(int tileX, int tileY, int tileID, int tilingIndex);
-        void DrawEntity(int posX, int posY, int lastX, int lastY, int id, bool flip, int animation, int metadata);
+        void DrawEntity(Entity* entity, bool tickedThisFrame, float delta);
         void DrawParticle(float posX, float posY, int id, float percentage);
         
         void SetDialogueText(const char* newText, int ticks = 50);

--- a/Entities/AI/ai_manager.cpp
+++ b/Entities/AI/ai_manager.cpp
@@ -87,7 +87,7 @@ void AIManager::TickAI(Entity* entity) {
 }
 void AIManager::TickSheep(Sheep* sheep) {
     if (!((tick % 2) == 0 || distGrid(sheep->x, sheep->y, shepherd->x, shepherd->y) > 5)) return;
-    sheep->animation = 0;
+    sheep->animation = AnimationID::ANIM_Idle;
     
     int dirX = 0;
     int dirY = 0;
@@ -109,7 +109,7 @@ void AIManager::TickWolf(Wolf* wolf) {
     
     if (!wolf->IsHunting()) { // If the wolf is not in hunt mode, select a target and begin the hunt
         if (enemyGoal) wolf->InitiateHunt(enemyGoal);
-        else wolf->animation = 0; // Idle stance if no target
+        else wolf->animation = AnimationID::ANIM_Idle; // Idle stance if no target
 
         return;
     }
@@ -132,5 +132,5 @@ void AIManager::TickWolf(Wolf* wolf) {
     GetNextMovement(wolf->x, wolf->y, wolf->currentPath, &dirX, &dirY);
 
     Movement_ShiftEntity(level, entities, wolf, dirX, -dirY);
-    wolf->animation = 1; // Run animation
+    wolf->animation = AnimationID::ANIM_Walk; // Run animation
 }

--- a/Entities/Subclasses/Boss/pyramidgolem.cpp
+++ b/Entities/Subclasses/Boss/pyramidgolem.cpp
@@ -172,3 +172,22 @@ void PyramidGolem::SetTarget(Entity* newTarget) {
 Entity* PyramidGolem::GetTarget() {
     return target;
 }
+
+
+void PyramidGolem::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    animationTimerTime += delta;
+
+    double angle = 0.0;
+    SDL_Rect src;
+    src.h = 128;
+    src.w = 128;
+    src.x = 0;
+    src.y = 0;
+
+    tile->w *= 4;
+    tile->h *= 4;
+    tile->x -= tile->w / 2;
+    tile->y -= tile->h / 2;
+
+    SDL_RenderCopyEx(canvas, texture, &src, tile, angle, NULL, SDL_FLIP_NONE);
+}

--- a/Entities/Subclasses/Boss/pyramidgolem.h
+++ b/Entities/Subclasses/Boss/pyramidgolem.h
@@ -50,4 +50,7 @@ class PyramidGolem : public Entity {
 
         void SetTarget(Entity* newTarget);
         Entity* GetTarget();
+
+
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
 };

--- a/Entities/Subclasses/fireball.cpp
+++ b/Entities/Subclasses/fireball.cpp
@@ -80,3 +80,18 @@ void Fireball::BurstEnemy(Entity* hit) {
     hit->HasFrost = HasFrost;
     hit->TakeDamage(1, this); // if (!enemy)
 };
+
+
+void Fireball::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    animationTimerTime += delta;
+
+    int sha = (int) 20 * (sin(animationTimerTime * 20) + 1);
+    SDL_SetRenderDrawColor(canvas, 210 + sha, 100 + sha, 0, 0);
+
+    tile->x += tile->w*.25;
+    tile->y += tile->h*.25;
+    tile->w *= .5;
+    tile->h *= .5;
+
+    SDL_RenderFillRect(canvas, tile);
+}

--- a/Entities/Subclasses/fireball.cpp
+++ b/Entities/Subclasses/fireball.cpp
@@ -11,10 +11,10 @@ Fireball::Fireball(int spawnX, int spawnY, int dirX, int dirY, int type) {
     
     if (type > 1) {
         HasFrost = true;
-        animation = 1;
+        animation = AnimationID::ANIM_Walk;
     } else {
         HasFire = true;
-        animation = 0;
+        animation = AnimationID::ANIM_Idle;
     }
 }
 

--- a/Entities/Subclasses/fireball.h
+++ b/Entities/Subclasses/fireball.h
@@ -25,6 +25,8 @@ class Fireball : public Entity {
         bool enemy = false;
 
         void Burst(Entity** entities, Particle* particles);
+
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
     
     private:
         void BurstTorch(Torch* torch);

--- a/Entities/Subclasses/lever.cpp
+++ b/Entities/Subclasses/lever.cpp
@@ -30,9 +30,9 @@ void Lever::UpdateAnimationData() {
         animationMetadata = 0;
     
     if (Flipped)
-        animation = 1;
+        animation = AnimationID::ANIM_Walk;
     else
-        animation = 0;
+        animation = AnimationID::ANIM_Idle;
 }
 
 void Lever::Tick() {

--- a/Entities/Subclasses/lever.cpp
+++ b/Entities/Subclasses/lever.cpp
@@ -23,24 +23,31 @@ bool Lever::IsLocked() {
 }
 
 
-void Lever::UpdateAnimationData() {
-    if (Locked)
-        animationMetadata = 1;
-    else
-        animationMetadata = 0;
-    
-    if (Flipped)
-        animation = AnimationID::ANIM_Walk;
-    else
-        animation = AnimationID::ANIM_Idle;
-}
-
 void Lever::Tick() {
-    UpdateAnimationData();
     if (lastState != Flipped) {
         stateChanged = true;
     } else {
         stateChanged = false;
     }
     lastState = Flipped;
+}
+
+
+void Lever::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    SDL_Rect src;
+    src.h = 32;
+    src.w = 32;
+    src.x = 0; // Default to unflipped texture
+    src.y = 0;
+
+    if (Flipped) {  // Flipped texture
+        src.x = 32;
+    }
+    
+    SDL_RenderCopyEx(canvas, texture, &src, tile, 0, NULL, SDL_FLIP_NONE);
+
+    if (Locked) { // Layer Lock ontop of lever
+        src.y = 32;
+        SDL_RenderCopyEx(canvas, texture, &src, tile, 0, NULL, SDL_FLIP_NONE);
+    }
 }

--- a/Entities/Subclasses/lever.h
+++ b/Entities/Subclasses/lever.h
@@ -12,8 +12,6 @@ class Lever : public Entity {
         bool Locked = false;
         bool lastState = false;
 
-        void UpdateAnimationData();
-
     public:
         void ToggleLock(bool lock);
 
@@ -24,4 +22,5 @@ class Lever : public Entity {
         bool IsLocked();
 
         virtual void Tick() override;
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
 };

--- a/Entities/Subclasses/sheep.cpp
+++ b/Entities/Subclasses/sheep.cpp
@@ -8,8 +8,6 @@ Sheep::Sheep(int xPos, int yPos) {
     lastY = yPos;
     MaxHealth = 2;
     Health = 2;
-
-    animationMetadata = Health;
 }
 
 void Sheep::Unload() {
@@ -32,8 +30,6 @@ bool Sheep::TakeDamage(int dmgAmount, Entity* attacker) {
 
 
 void Sheep::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
-    animationTimerTicks++;
-
     SDL_Rect src;
     src.w = 32;
     src.h = 32;
@@ -41,18 +37,13 @@ void Sheep::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, flo
     src.y = 0;
 
     double angle = 0.0;
-    int step = animationTimerTicks % 4;
+    int step = (animationTimerTicks / 2) % 4;
 
     switch (animation) {
         case AnimationID::ANIM_Paused:
             src.x = 64;
             break;
-        case AnimationID::ANIM_Idle:
-        case AnimationID::ANIM_Walk:
-        default:
-            src.x = (animationTimerTicks/2 % 2) * 32;
-
-            // Set angle based off of range of 1 to 3
+        case AnimationID::ANIM_Walk: // Set angle based off of range of 1 to 3
             switch (step) {
                 case 0:
                     angle = 3.0;
@@ -62,7 +53,12 @@ void Sheep::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, flo
                     break;
                 default:
                     angle = 0;
+                    break;
             }
+        case AnimationID::ANIM_Idle:
+        default:
+            src.x = (animationTimerTicks/2 % 2) * 32;
+            break;
     }
 
     SDL_RenderCopyEx(canvas, texture, &src, tile, angle, NULL, GetFlipStyle());

--- a/Entities/Subclasses/sheep.cpp
+++ b/Entities/Subclasses/sheep.cpp
@@ -16,10 +16,7 @@ void Sheep::Unload() {
     Path_FreePath(currentPath);
     currentPath = nullptr;
 }
-void Sheep::Pause() {
-    Entity::Pause();
-    animation = 1;
-}
+
 
 bool Sheep::TakeDamage(int dmgAmount, Entity* attacker) {
     if (Armored) {
@@ -28,8 +25,52 @@ bool Sheep::TakeDamage(int dmgAmount, Entity* attacker) {
     }
 
     Health-=dmgAmount;
-
-    animationMetadata = Health;
+    ResetAnimationTimers();
 
     return Health <= 0;
+}
+
+
+void Sheep::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    animationTimerTicks++;
+
+    SDL_Rect src;
+    src.w = 32;
+    src.h = 32;
+    src.x = 0;
+    src.y = 0;
+
+    double angle = 0.0;
+    int step = animationTimerTicks % 4;
+
+    switch (animation) {
+        case AnimationID::ANIM_Paused:
+            src.x = 64;
+            break;
+        case AnimationID::ANIM_Idle:
+        case AnimationID::ANIM_Walk:
+        default:
+            src.x = (animationTimerTicks/2 % 2) * 32;
+
+            // Set angle based off of range of 1 to 3
+            switch (step) {
+                case 0:
+                    angle = 3.0;
+                    break;
+                case 2:
+                    angle = -3.0;
+                    break;
+                default:
+                    angle = 0;
+            }
+    }
+
+    SDL_RenderCopyEx(canvas, texture, &src, tile, angle, NULL, GetFlipStyle());
+
+    // Overlay blood
+    if (Health < MaxHealth) {
+        src.y = 32;
+        SDL_RenderCopyEx(canvas, texture, &src, tile, angle, NULL, GetFlipStyle());
+    }
+    // Overlay armor (not used as of currently)
 }

--- a/Entities/Subclasses/sheep.h
+++ b/Entities/Subclasses/sheep.h
@@ -14,12 +14,13 @@ class Sheep : public Entity {
 
     public:
         virtual void Unload() override;
-        virtual void Pause() override;
 
         // Called when the entity takes damage; returns true if killed
         // -   If the sheep is armored, it deals 3 damage to the attacker and loses its armor
         virtual bool TakeDamage(int dmgAmount, Entity* attacker) override;
 
+
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
 
         // Armored - If a sheep is armored, they have an additional point of health
         // Any wolves that attack an armored sheep are destroyed at the cost of the armor

--- a/Entities/Subclasses/shepherd.cpp
+++ b/Entities/Subclasses/shepherd.cpp
@@ -157,7 +157,8 @@ void Shepherd::SwingAttack(Entity** entities, Particle* particles, SoundService*
             for (int z = y-1; z < y+2; z++) {
                 Entity* obj = GetEntityAtLocation(entities, w, z);
                 if (obj && obj->GetID() == EntityID::EE_Sheep) { //If sheep, toggle pause
-                    obj->Pause();
+                    if (NewPause) obj->Pause();
+                    else obj->Paused = false;
                 }
             }
         }
@@ -165,8 +166,6 @@ void Shepherd::SwingAttack(Entity** entities, Particle* particles, SoundService*
 }
 
 void Shepherd::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
-    animationTimerTicks++;
-
     SDL_Rect src;
     src.h = 32;
     src.w = 32;
@@ -174,7 +173,8 @@ void Shepherd::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, 
     src.y = 0;
 
     double angle = 0.0;
-    int step = (animationTimerTicks / TickRate) % 2;
+    int stepSlow = (animationTimerTicks / 2) % 2;
+    int stepFast = animationTimerTicks % 2;
 
     // Attack and pause sprites are wider than default sprites
     switch (animation) {
@@ -191,8 +191,8 @@ void Shepherd::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, 
     switch (animation) {
         case AnimationID::ANIM_Walk:
             src.w = 12;
-            src.x = 20 + step * 12; // Alternate between frames 3 and 4
-            angle = (((double) step) - 0.5) * 15;
+            src.x = 20 + stepSlow * 12; // Alternate between frames 3 and 4
+            angle = (((double) stepFast) - 0.5) * 15;
             break;
         case AnimationID::ANIM_Attack:
             src.w = 23;
@@ -205,7 +205,7 @@ void Shepherd::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, 
         case AnimationID::ANIM_Idle:
         default:
             src.w = 10;
-            src.x = step * 10; // Alternate between frames 0 and 1
+            src.x = stepSlow * 10; // Alternate between frames 0 and 1
     }
 
     SDL_RenderCopyEx(canvas, texture, &src, tile, angle, NULL, GetFlipStyle());

--- a/Entities/Subclasses/shepherd.cpp
+++ b/Entities/Subclasses/shepherd.cpp
@@ -13,23 +13,10 @@ Shepherd::Shepherd(int spawnX, int spawnY) {
 }
 
 
-void Shepherd::Tick() {
-    if (HasFire)
-        animationMetadata = 1;
-    else if (HasFrost)
-        animationMetadata = 2;
-    else
-        animationMetadata = 0;
-}
-void Shepherd::Pause() {
-    Entity::Pause();
-    animation = 3;
-}
-
-
 void Shepherd::SlingFireball(Entity** entities, Particle* particles, SoundService* soundService) {
     HasFire = false;
-    animation = 2; // Fireball Toss animation
+    animation = AnimationID::ANIM_Attack; // Fireball Toss animation
+    ResetAnimationTimers();
     
     Fireball* fireball = new Fireball(x, y, faceX, faceY, 0);
     fireball->enemy = false;
@@ -37,8 +24,9 @@ void Shepherd::SlingFireball(Entity** entities, Particle* particles, SoundServic
     soundService->PlaySound("Assets/Audio/FireballSling.wav");
 }
 void Shepherd::SwingAttack(Entity** entities, Particle* particles, SoundService* soundService) {
-    animation = 2;
+    animation = AnimationID::ANIM_Attack;
     ActivateParticle(particles, 1, x, y);
+    ResetAnimationTimers();
 
     int sheepFound = 0;
     int pausedSheep = 0;
@@ -169,10 +157,67 @@ void Shepherd::SwingAttack(Entity** entities, Particle* particles, SoundService*
             for (int z = y-1; z < y+2; z++) {
                 Entity* obj = GetEntityAtLocation(entities, w, z);
                 if (obj && obj->GetID() == EntityID::EE_Sheep) { //If sheep, toggle pause
-                    obj->Paused = NewPause;
-                    obj->animation = 1;
+                    obj->Pause();
                 }
             }
         }
+    }
+}
+
+void Shepherd::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    animationTimerTicks++;
+
+    SDL_Rect src;
+    src.h = 32;
+    src.w = 32;
+    src.x = 0;
+    src.y = 0;
+
+    double angle = 0.0;
+    int step = (animationTimerTicks / TickRate) % 2;
+
+    // Attack and pause sprites are wider than default sprites
+    switch (animation) {
+        case AnimationID::ANIM_Attack:
+        case AnimationID::ANIM_Paused:
+            tile->x += tile->w/6;
+            tile->w *= (float) 2 / (float) 3;
+            break;
+        default:
+            tile->x += tile->w/3;
+            tile->w /= 3;
+    }
+
+    switch (animation) {
+        case AnimationID::ANIM_Walk:
+            src.w = 12;
+            src.x = 20 + step * 12; // Alternate between frames 3 and 4
+            angle = (((double) step) - 0.5) * 15;
+            break;
+        case AnimationID::ANIM_Attack:
+            src.w = 23;
+            src.x = 44;
+            break;
+        case AnimationID::ANIM_Paused:
+            src.w = 24;
+            src.x = 67;
+            break;
+        case AnimationID::ANIM_Idle:
+        default:
+            src.w = 10;
+            src.x = step * 10; // Alternate between frames 0 and 1
+    }
+
+    SDL_RenderCopyEx(canvas, texture, &src, tile, angle, NULL, GetFlipStyle());
+
+    // Draw Fire Overlays
+    if (HasFire || HasFrost) {
+        if (HasFrost) {
+            src.y = 64;
+        } else {
+            src.y = 32;
+        }
+
+        SDL_RenderCopyEx(canvas, texture, &src, tile, angle, NULL, GetFlipStyle());
     }
 }

--- a/Entities/Subclasses/shepherd.h
+++ b/Entities/Subclasses/shepherd.h
@@ -26,8 +26,7 @@ class Shepherd : public Entity {
 
         int ticksIdled = 0;
 
-        virtual void Tick() override;
-        virtual void Pause() override;
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
 
         // Causes Shepherd to sling a fireball; based off last direction they moved
         void SlingFireball(Entity** entities, Particle* particles, SoundService* soundService);

--- a/Entities/Subclasses/torch.cpp
+++ b/Entities/Subclasses/torch.cpp
@@ -24,14 +24,41 @@ void Torch::UpdateAnimationData() {
         animationMetadata = 0;
     
     if (glow)
-        animation = 1;
+        animation = AnimationID::ANIM_Walk;
     else
-        animation = 0;
+        animation = AnimationID::ANIM_Idle;
 }
 
 void Torch::Extinguish(bool Override) {
     if (Extinguishable || Override) {
         HasFire = false;
         HasFrost = false;
+        ResetAnimationTimers();
+    }
+}
+
+void Torch::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    animationTimerTicks++;
+
+    SDL_Rect src;
+    src.h = 32;
+    src.w = 32;
+    src.x = 0;
+    src.y = 0;
+
+    if (animation == AnimationID::ANIM_Walk) {  // Glowing Base Texture
+        src.x = 32;
+    }
+    
+    // Draw base texture
+    SDL_RenderCopyEx(canvas, texture, &src, tile, 0, NULL, GetFlipStyle());
+
+    // Overlay fire
+    if (HasFire || HasFrost) {
+        src.x = (animationTimerTicks % 2) * 32;
+        if (HasFrost) src.y = 64;
+        else src.y = 32;
+
+        SDL_RenderCopyEx(canvas, texture, &src, tile, 0, NULL, GetFlipStyle());
     }
 }

--- a/Entities/Subclasses/torch.cpp
+++ b/Entities/Subclasses/torch.cpp
@@ -8,25 +8,6 @@ Torch::Torch(int xPos, int yPos) {
 
     Solid = true;
     HasFire = true;
-    UpdateAnimationData();
-}
-void Torch::Tick() {
-    UpdateAnimationData();
-}
-
-
-void Torch::UpdateAnimationData() {
-    if (HasFire)
-        animationMetadata = 1;
-    else if (HasFrost)
-        animationMetadata = 2;
-    else
-        animationMetadata = 0;
-    
-    if (glow)
-        animation = AnimationID::ANIM_Walk;
-    else
-        animation = AnimationID::ANIM_Idle;
 }
 
 void Torch::Extinguish(bool Override) {
@@ -38,15 +19,13 @@ void Torch::Extinguish(bool Override) {
 }
 
 void Torch::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
-    animationTimerTicks++;
-
     SDL_Rect src;
     src.h = 32;
     src.w = 32;
     src.x = 0;
     src.y = 0;
 
-    if (animation == AnimationID::ANIM_Walk) {  // Glowing Base Texture
+    if (glow) {  // Glowing Base Texture
         src.x = 32;
     }
     

--- a/Entities/Subclasses/torch.h
+++ b/Entities/Subclasses/torch.h
@@ -7,9 +7,6 @@
 class Torch : public Entity {
     public:
         Torch(int xPos, int yPos);
-
-        virtual void Tick() override;
-
         virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
 
         // Do we want the torch to have a glowing effect (gives 'activated' sort of feel)?
@@ -19,9 +16,6 @@ class Torch : public Entity {
         bool Extinguishable = true;
         // Is the player able to retrieve the fire from this torch?
         bool FireUsable = true;
-
-        // Updates animation data for whenever torch is manipulated.
-        void UpdateAnimationData();
         
         // Extinguishes the torch (both fire and frost)
         // - Only works if the torch can be extinguished (unless overriden)

--- a/Entities/Subclasses/torch.h
+++ b/Entities/Subclasses/torch.h
@@ -10,6 +10,8 @@ class Torch : public Entity {
 
         virtual void Tick() override;
 
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
+
         // Do we want the torch to have a glowing effect (gives 'activated' sort of feel)?
         bool glow = false;
 

--- a/Entities/Subclasses/wolf.cpp
+++ b/Entities/Subclasses/wolf.cpp
@@ -38,14 +38,14 @@ void Wolf::TickStun() {
 // Howl and begin pursuit of new target.
 void Wolf::InitiateHunt(Entity* newTarget) {
     target = newTarget;
-    animation = 2;
+    animation = AnimationID::ANIM_Attack;
     stun = 5;
 }
 // Forcefully end the current hunt, clearing target and having the wolf pause for a second.
 // Use when unloading wolves to prevent crashing from attempting to pursue non-existant entities
 void Wolf::EndHunt() {
     target = nullptr;
-    animation = 0;
+    animation = AnimationID::ANIM_Idle;
     stun = 1;
 }
 // Is the wolf currently pursuing an existing entity that isn't dead?

--- a/Entities/Subclasses/wolf.cpp
+++ b/Entities/Subclasses/wolf.cpp
@@ -60,3 +60,27 @@ bool Wolf::IsHunting() {
 Entity* Wolf::GetTarget() {
     return target;
 }
+
+
+void Wolf::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    SDL_Rect src;
+    src.h = 32;
+    src.w = 32;
+    src.y = 0;
+
+    switch (animation) {
+        case AnimationID::ANIM_Walk:
+            src.x = 64 + ((animationTimerTicks / 2) % 2) * 32;
+            break;
+        case AnimationID::ANIM_Attack: // Attack / Howl
+            src.x = 128;
+            break;
+        case AnimationID::ANIM_Paused: // Sleep
+            src.x = 160 + ((animationTimerTicks / 6) % 2) * 32;
+            break;
+        default:
+            src.x = ((animationTimerTicks / 4) % 2) * 32;
+    }
+
+    SDL_RenderCopyEx(canvas, texture, &src, tile, 0, NULL, GetFlipStyle());
+}

--- a/Entities/Subclasses/wolf.h
+++ b/Entities/Subclasses/wolf.h
@@ -14,6 +14,7 @@ class Wolf : public Entity {
 
     public:
         virtual void Unload() override;
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) override;
 
         bool InStun();
         void TickStun();

--- a/Entities/entity.cpp
+++ b/Entities/entity.cpp
@@ -28,9 +28,22 @@ void Entity::Tick() {
 }
 void Entity::Pause() {
     Paused = true;
+    animation = AnimationID::ANIM_Paused;
 }
 bool Entity::TakeDamage(int dmgAmount, Entity* attacker) {
     Health-=dmgAmount;
 
     return Health <= 0;
+}
+
+SDL_RendererFlip Entity::GetFlipStyle() {
+    // Return a horizontal flip if the sprite is flipped--otherwise return no flip
+    return Flipped ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE;
+}
+void Entity::ResetAnimationTimers() {
+    animationTimerTicks = 0;
+    animationTimerTime = 0.0f;
+}
+void Entity::Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta) {
+    SDL_RenderCopy(canvas, texture, NULL, tile); // Render entire given texture as default
 }

--- a/Entities/entity.h
+++ b/Entities/entity.h
@@ -70,8 +70,6 @@ class Entity {
 
         // Current animation playing--0 is always idle, animations are defined per-object inside the RenderWindow class
         AnimationID animation = AnimationID::ANIM_Idle;
-        // Animation Metadata; entity-specific data for the renderer to interpret when drawing entities or animations
-        int animationMetadata = 0;
         // Animation timer in game ticks
         unsigned int animationTimerTicks = 0;
         // Animation timer in real seconds

--- a/Entities/entity.h
+++ b/Entities/entity.h
@@ -2,6 +2,7 @@
 
 #include "Core/config.h"
 #include "Core/enums.h"
+#include "SDL2/SDL.h"
 
 // Entity - Any mobile object with individual properties.
 class Entity {
@@ -28,6 +29,16 @@ class Entity {
 
         // Called when the entity takes damage; returns true if killed
         virtual bool TakeDamage(int dmgAmount, Entity* attacker);
+
+
+        // RENDERING //
+        
+        // Gets flip style of entity for rendering
+        SDL_RendererFlip GetFlipStyle();
+        // Resets entity animation timers
+        void ResetAnimationTimers();
+        // Draws the entity
+        virtual void Draw(SDL_Renderer* canvas, SDL_Texture* texture, SDL_Rect* tile, float delta);
 
 
         // Horizontal position of Entity
@@ -58,9 +69,13 @@ class Entity {
         bool OnPressurePlate = false;
 
         // Current animation playing--0 is always idle, animations are defined per-object inside the RenderWindow class
-        int animation = 0;
+        AnimationID animation = AnimationID::ANIM_Idle;
         // Animation Metadata; entity-specific data for the renderer to interpret when drawing entities or animations
         int animationMetadata = 0;
+        // Animation timer in game ticks
+        unsigned int animationTimerTicks = 0;
+        // Animation timer in real seconds
+        float animationTimerTime = 0.0f;
 
         // If true, entity can be saved to or removed from levels upon entering and leaving
         bool archivable = false;

--- a/Entities/movement.cpp
+++ b/Entities/movement.cpp
@@ -219,7 +219,7 @@ void Movement_ShiftPlayer(Map* world, Entity* entities[MaxEntities], Shepherd* o
 
     obj->faceX = sgn(dx);
     obj->faceY = sgn(dy);
-    obj->animation = 1;     //Set animation to walking
+    obj->animation = AnimationID::ANIM_Walk;     //Set animation to walking
     obj->ticksIdled = 0;
 
     if (desiredX >= MapWidth && *worldX+1 <= WorldWidth-1 && HasAllSheep(entities, obj)) {

--- a/Triggers/trigger_util.cpp
+++ b/Triggers/trigger_util.cpp
@@ -40,7 +40,6 @@ void Trigger_Internal_DisplayPuzzleStatus_Torch(Entity* torch, bool puzzleStatus
             t->FireUsable = false;
             t->HasFire = puzzleStatus;
             t->glow = puzzleStatus;
-            t->UpdateAnimationData();
         }
     }
 }

--- a/Triggers/triggers.cpp
+++ b/Triggers/triggers.cpp
@@ -37,14 +37,7 @@ void Trigger_OnFizzler(RenderWindow* window, SoundService* soundService, Map* ma
 void Trigger_GameStart(RenderWindow* window, SoundService* soundService, Map* map, Entity* entities[]) {
     // Starting Level Cinematic
     for (int i = 0; i < MaxEntities; i++) {
-        Entity* ent = entities[i];
-        if (ent) {
-            ent->Paused = true;
-            if (ent->GetID() == EntityID::EE_Sheep)
-                ent->animation = 1;
-            else if (ent->GetID() == EntityID::EE_Shepherd)
-                ent->animation = 3;
-        }
+        if (entities[i]) entities[i]->Pause();
     }
     window->SetDialogueText("\nHit spacebar to rally your sheep.", 0);
 
@@ -61,16 +54,11 @@ void Trigger_GameOver(RenderWindow* window, SoundService* soundService, Map* map
     for (int i = 0; i < MaxEntities; i++) {
         Entity* ent = entities[i];
         if (ent) {
-            ent->Paused = true;
+            ent->Pause();
             ent->lastX = ent->x;
             ent->lastY = ent->y;
             ent->shovedX = 0;
             ent->shovedY = 0;
-            switch (ent->GetID()) {
-                case EntityID::EE_Sheep: ent->animation = 1; break;
-                case EntityID::EE_Wolf: ent->animation = 2; break;
-                case EntityID::EE_Shepherd: ent->animation = 3; break;
-            }
         }
     }
     window->SetDialogueText("\nLet the tears flow.", 0);


### PR DESCRIPTION
Moves entity drawing out of RenderWindow and into individual entities. This reduces the need for generalized state variables for animation data, removes the need for animation updating functions (like on torches), and adds a new Enum for AnimationIDs.

Note compilation time is increased a little.